### PR TITLE
Fix build errors on Windows

### DIFF
--- a/acos5/src/lib.rs
+++ b/acos5/src/lib.rs
@@ -71,7 +71,6 @@ use std::ptr::{copy_nonoverlapping, null_mut, null};
 use std::collections::HashMap;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::convert::TryFrom;
-#[cfg(not(target_os = "windows"))]
 use std::convert::TryInto;
 
 // use ::function_name::named;

--- a/acos5_pkcs15/src/lib.rs
+++ b/acos5_pkcs15/src/lib.rs
@@ -145,9 +145,10 @@ pub mod    missing_exports; // this is NOT the same as in acos5
 use crate::missing_exports::{me_profile_get_file, me_pkcs15_dup_bignum/*, my_file_dup*/};
 
 pub mod    no_cdecl; // this is NOT the same as in acos5
-use crate::no_cdecl::{rsa_modulus_bits_canonical, first_of_free_indices, construct_sym_key_entry, free_fid_asym,
-                      check_enlarge_prkdf_pukdf
-}; /*call_dynamic_update_hashmap, call_dynamic_sm_test,*/
+use crate::no_cdecl::{rsa_modulus_bits_canonical, first_of_free_indices, construct_sym_key_entry, free_fid_asym}; /*call_dynamic_update_hashmap, call_dynamic_sm_test,*/
+
+#[cfg(not(target_os = "windows"))]
+use crate::no_cdecl::{check_enlarge_prkdf_pukdf};
 
 cfg_if::cfg_if! {
     if #[cfg(not(target_os = "windows"))] {


### PR DESCRIPTION
I encountered some build errors when running `cargo build` on Windows, so I adjusted some conditions to get it working. Tested on Windows 10 x64 and Ubuntu 20.04 x64.